### PR TITLE
bin/dune: update mcp public name to mcp-client

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -53,7 +53,7 @@
   jsonschema
   re
   cmdliner
-  merlin-lib
+  (merlin-lib (>= 5.5))
   ocamlformat-lib
   (ppx_deriving_yojson
    (>= 3.9.0))))

--- a/ocaml-mcp-server.opam
+++ b/ocaml-mcp-server.opam
@@ -21,7 +21,7 @@ depends: [
   "jsonschema"
   "re"
   "cmdliner"
-  "merlin-lib"
+  "merlin-lib" {>= "5.5"}
   "ocamlformat-lib"
   "ppx_deriving_yojson" {>= "3.9.0"}
   "odoc" {with-doc}

--- a/test/build-status.t/run.t
+++ b/test/build-status.t/run.t
@@ -38,7 +38,7 @@ Start dune RPC and MCP server:
   $ SERVER_PID=$!
   $ sleep 1
 
-  $ mcp-client --pipe test.sock call dune/build-status
+  $ mcp --pipe test.sock call dune/build-status
   Build waiting...
 
 Clean up:

--- a/test/build-target.t/run.t
+++ b/test/build-target.t/run.t
@@ -100,37 +100,37 @@ Start dune RPC and MCP server:
 
 Test building the library:
 
-  $ mcp-client --pipe test.sock call dune/build-target -a '{"targets":["lib/mylib.cma"]}'
+  $ mcp --pipe test.sock call dune/build-target -a '{"targets":["lib/mylib.cma"]}'
   Building targets: lib/mylib.cma
   Success
 
 Test building the executable:
 
-  $ mcp-client --pipe test.sock call dune/build-target -a '{"targets":["bin/main.exe"]}'
+  $ mcp --pipe test.sock call dune/build-target -a '{"targets":["bin/main.exe"]}'
   Building targets: bin/main.exe
   Success
 
 Test building multiple targets:
 
-  $ mcp-client --pipe test.sock call dune/build-target -a '{"targets":["lib/mylib.cma", "bin/main.exe"]}'
+  $ mcp --pipe test.sock call dune/build-target -a '{"targets":["lib/mylib.cma", "bin/main.exe"]}'
   Building targets: lib/mylib.cma bin/main.exe
   Success
 
 Test building all:
 
-  $ mcp-client --pipe test.sock call dune/build-target -a '{"targets":["@all"]}'
+  $ mcp --pipe test.sock call dune/build-target -a '{"targets":["@all"]}'
   Building targets: @all
   Success
 
 Test building the test:
 
-  $ mcp-client --pipe test.sock call dune/build-target -a '{"targets":["@test/runtest"]}'
+  $ mcp --pipe test.sock call dune/build-target -a '{"targets":["@test/runtest"]}'
   Building targets: @test/runtest
   Success
 
 Test building a non-existent target:
 
-  $ mcp-client --pipe test.sock call dune/build-target -a '{"targets":["nonexistent.exe"]}'
+  $ mcp --pipe test.sock call dune/build-target -a '{"targets":["nonexistent.exe"]}'
   Building targets: nonexistent.exe
   Error: Don't know how to build nonexistent.exe
   Error: Build failed with 1 error.

--- a/test/dune
+++ b/test/dune
@@ -1,2 +1,2 @@
 (cram
- (deps %{bin:ocaml-mcp-server} %{bin:mcp-client}))
+ (deps %{bin:ocaml-mcp-server} %{bin:mcp}))

--- a/test/eval.t/dune
+++ b/test/eval.t/dune
@@ -1,4 +1,4 @@
 (cram
  (deps
   %{bin:ocaml-mcp-server}
-  %{bin:mcp-client}))
+  %{bin:mcp}))

--- a/test/eval.t/run.t
+++ b/test/eval.t/run.t
@@ -80,29 +80,29 @@ Start the MCP server in the background
   $ sleep 1
 
 Test evaluating a simple expression:
-  $ mcp-client --pipe test.sock call ocaml/eval -a '{"code":"1 + 1"}'
+  $ mcp --pipe test.sock call ocaml/eval -a '{"code":"1 + 1"}'
   - : int = 2
-  
+
 Test evaluating a let binding:
-  $ mcp-client --pipe test.sock call ocaml/eval -a '{"code":"let x = 42"}'
+  $ mcp --pipe test.sock call ocaml/eval -a '{"code":"let x = 42"}'
   val x : int = 42
-  
+
 Test evaluating an expression using the previous binding:
-  $ mcp-client --pipe test.sock call ocaml/eval -a '{"code":"x * 2"}'
+  $ mcp --pipe test.sock call ocaml/eval -a '{"code":"x * 2"}'
   - : int = 84
-  
+
 Test evaluating a function definition:
-  $ mcp-client --pipe test.sock call ocaml/eval -a '{"code":"let double x = x * 2"}'
+  $ mcp --pipe test.sock call ocaml/eval -a '{"code":"let double x = x * 2"}'
   val double : int -> int = <fun>
-  
+
 Test calling the function:
-  $ mcp-client --pipe test.sock call ocaml/eval -a '{"code":"double 21"}'
+  $ mcp --pipe test.sock call ocaml/eval -a '{"code":"double 21"}'
   - : int = 42
-  
+
 Test evaluating invalid code:
-  $ mcp-client --pipe test.sock call ocaml/eval -a '{"code":"let x ="}'
+  $ mcp --pipe test.sock call ocaml/eval -a '{"code":"let x ="}'
   File "_none_", line 1, characters 7-9:
   Error: Syntax error
-  
+
 Kill the server
   $ kill $SERVER_PID 2>/dev/null

--- a/test/fs-tools.t/dune
+++ b/test/fs-tools.t/dune
@@ -1,4 +1,4 @@
 (cram
  (deps
   %{bin:ocaml-mcp-server}
-  %{bin:mcp-client}))
+  %{bin:mcp}))

--- a/test/fs-tools.t/run.t
+++ b/test/fs-tools.t/run.t
@@ -204,7 +204,7 @@ Start the MCP server in the background
   $ sleep 1
 
 Basic fs/write - Create a simple OCaml file:
-  $ mcp-client --pipe test.sock call fs/write -a '{"file_path":"hello.ml","content":"let greeting = \"Hello, world!\"\nlet () = print_endline greeting"}'
+  $ mcp --pipe test.sock call fs/write -a '{"file_path":"hello.ml","content":"let greeting = \"Hello, world!\"\nlet () = print_endline greeting"}'
   Wrote ./hello.ml (formatted, no diagnostics)
 
 Verify the file was created:
@@ -213,11 +213,11 @@ Verify the file was created:
   let () = print_endline greeting
 
 Basic fs/read - Read the file back:
-  $ mcp-client --pipe test.sock call fs/read -a '{"file_path":"hello.ml"}'
+  $ mcp --pipe test.sock call fs/read -a '{"file_path":"hello.ml"}'
   Read ./hello.ml (no diagnostics)
 
 Basic fs/edit - Modify the greeting:
-  $ mcp-client --pipe test.sock call fs/edit -a '{"file_path":"hello.ml","old_string":"\"Hello, world!\"","new_string":"\"Hello, OCaml!\""}'
+  $ mcp --pipe test.sock call fs/edit -a '{"file_path":"hello.ml","old_string":"\"Hello, world!\"","new_string":"\"Hello, OCaml!\""}'
   Edited ./hello.ml (1 replacements, formatted, no diagnostics)
 
 Verify the edit:
@@ -226,47 +226,47 @@ Verify the edit:
   let () = print_endline greeting
 
 Test automatic formatting with fs/write:
-  $ mcp-client --pipe test.sock call fs/write -a '{"file_path":"unformatted.ml","content":"let    x=1+2\n  let y  =   3"}' 2>&1 | grep -q "format_result" && echo "Formatting attempted"
+  $ mcp --pipe test.sock call fs/write -a '{"file_path":"unformatted.ml","content":"let    x=1+2\n  let y  =   3"}' 2>&1 | grep -q "format_result" && echo "Formatting attempted"
   [1]
 
 Test fs/write with modules:
-  $ mcp-client --pipe test.sock call fs/write -a '{"file_path":"module.ml","content":"module M = struct\n  let value = 42\nend"}'
+  $ mcp --pipe test.sock call fs/write -a '{"file_path":"module.ml","content":"module M = struct\n  let value = 42\nend"}'
   Wrote ./module.ml (formatted, no diagnostics)
 
 Test different OCaml file extensions (.mli):
-  $ mcp-client --pipe test.sock call fs/write -a '{"file_path":"interface.mli","content":"val compute : int -> int"}'
+  $ mcp --pipe test.sock call fs/write -a '{"file_path":"interface.mli","content":"val compute : int -> int"}'
   Wrote ./interface.mli (formatted, 1 diagnostics)
 
-  $ mcp-client --pipe test.sock call fs/read -a '{"file_path":"interface.mli"}' 2>&1 | grep "file_type"
+  $ mcp --pipe test.sock call fs/read -a '{"file_path":"interface.mli"}' 2>&1 | grep "file_type"
   [1]
 
 Test fs/write with a non-OCaml file:
-  $ mcp-client --pipe test.sock call fs/write -a '{"file_path":"README.md","content":"# Test Project\n\nThis is a test."}'
+  $ mcp --pipe test.sock call fs/write -a '{"file_path":"README.md","content":"# Test Project\n\nThis is a test."}'
   Successfully wrote to ./README.md
 
 Test fs/read on non-OCaml file:
-  $ mcp-client --pipe test.sock call fs/read -a '{"file_path":"README.md"}'
+  $ mcp --pipe test.sock call fs/read -a '{"file_path":"README.md"}'
   # Test Project
-  
+
   This is a test.
 
 Test fs/edit with non-existent file:
-  $ mcp-client --pipe test.sock call fs/edit -a '{"file_path":"nonexistent.ml","old_string":"foo","new_string":"bar"}' 2>&1 | grep -o "File not found"
+  $ mcp --pipe test.sock call fs/edit -a '{"file_path":"nonexistent.ml","old_string":"foo","new_string":"bar"}' 2>&1 | grep -o "File not found"
   File not found
 
 Test fs/read with non-existent file:
-  $ mcp-client --pipe test.sock call fs/read -a '{"file_path":"nonexistent.ml"}' 2>&1 | grep -o "File not found"
+  $ mcp --pipe test.sock call fs/read -a '{"file_path":"nonexistent.ml"}' 2>&1 | grep -o "File not found"
   File not found
 
 Test fs/write with invalid OCaml code (should still write but report issues):
-  $ mcp-client --pipe test.sock call fs/write -a '{"file_path":"bad.ml","content":"let x = "}' 2>&1 | grep -q "file_path" && echo "File written despite syntax error"
+  $ mcp --pipe test.sock call fs/write -a '{"file_path":"bad.ml","content":"let x = "}' 2>&1 | grep -q "file_path" && echo "File written despite syntax error"
   [1]
 
 Test fs/edit with replace_all option:
-  $ mcp-client --pipe test.sock call fs/write -a '{"file_path":"multi.ml","content":"let x = 1\nlet y = 1\nlet z = 1"}'
+  $ mcp --pipe test.sock call fs/write -a '{"file_path":"multi.ml","content":"let x = 1\nlet y = 1\nlet z = 1"}'
   Wrote ./multi.ml (formatted, no diagnostics)
 
-  $ mcp-client --pipe test.sock call fs/edit -a '{"file_path":"multi.ml","old_string":"1","new_string":"42","replace_all":true}'
+  $ mcp --pipe test.sock call fs/edit -a '{"file_path":"multi.ml","old_string":"1","new_string":"42","replace_all":true}'
   Edited ./multi.ml (3 replacements, formatted, no diagnostics)
 
   $ cat multi.ml
@@ -275,10 +275,10 @@ Test fs/edit with replace_all option:
   let z = 42
 
 Test fs/edit preserving OCaml structure:
-  $ mcp-client --pipe test.sock call fs/write -a '{"file_path":"func.ml","content":"let add x y = x + y\nlet multiply x y = x * y"}'
+  $ mcp --pipe test.sock call fs/write -a '{"file_path":"func.ml","content":"let add x y = x + y\nlet multiply x y = x * y"}'
   Wrote ./func.ml (formatted, no diagnostics)
 
-  $ mcp-client --pipe test.sock call fs/edit -a '{"file_path":"func.ml","old_string":"add","new_string":"sum"}'
+  $ mcp --pipe test.sock call fs/edit -a '{"file_path":"func.ml","old_string":"add","new_string":"sum"}'
   Edited ./func.ml (1 replacements, formatted, no diagnostics)
 
   $ cat func.ml

--- a/test/http.t/run.t
+++ b/test/http.t/run.t
@@ -6,15 +6,15 @@ Start the HTTP server:
   $ sleep 1
 
 Test server info:
-  $ mcp-client --socket 8080 info
+  $ mcp --socket 8080 info
   Server: ocaml-mcp-server v0.1.0
-  
+
   Capabilities:
   - Tools
   - Logging
 
 List tools:
-  $ mcp-client --socket 8080 list tools
+  $ mcp --socket 8080 list tools
   Tools (10):
   - fs/write: Write content to a file. For OCaml files (.ml/.mli), automatically formats the code and returns diagnostics.
   - dune/build-status: Get the current build status from dune, including any errors or warnings

--- a/test/project-structure.t/run.t
+++ b/test/project-structure.t/run.t
@@ -24,17 +24,17 @@ Start the MCP server for the test project:
   $ sleep 1
 
 Test calling project-structure tool (no args needed):
-  $ mcp-client --pipe test.sock call ocaml/project-structure
+  $ mcp --pipe test.sock call ocaml/project-structure
   Project Root: $TESTCASE_ROOT/test_project
   Build Context: default
-  
+
   COMPONENT: Executable
     Name: main
     Directory: bin
     Dependencies: mylib
     Action: Build: dune build bin/main.exe
     Action: Run: dune exec bin/main.exe
-  
+
   COMPONENT: Library
     Name: mylib
     Directory: lib

--- a/test/tools.t/run.t
+++ b/test/tools.t/run.t
@@ -1,4 +1,4 @@
-Test OCaml MCP Server tools functionality using mcp-client
+Test OCaml MCP Server tools functionality using mcp
 
 Start the MCP server in the background
   $ ocaml-mcp-server --pipe test.sock --no-dune -vv &
@@ -70,7 +70,7 @@ Start the MCP server in the background
   ocaml-mcp-server: [INFO] Received request: initialize (id: 0)
   ocaml-mcp-server: [DEBUG] Sending response
   ocaml-mcp-server: [INFO] Received request: tools/call (id: 1)
-  ocaml-mcp-server: [DEBUG] handle_module_signature called with module_path: 
+  ocaml-mcp-server: [DEBUG] handle_module_signature called with module_path:
   ocaml-mcp-server: [INFO] Tool ocaml/module-signature executed successfully
   ocaml-mcp-server: [DEBUG] Sending response
   ocaml-mcp-server: [INFO] Client disconnected
@@ -79,15 +79,15 @@ Start the MCP server in the background
   $ sleep 1
 
 Test server info:
-  $ mcp-client --pipe test.sock info
+  $ mcp --pipe test.sock info
   Server: ocaml-mcp-server v0.1.0
-  
+
   Capabilities:
   - Tools
   - Logging
 
 List available tools:
-  $ mcp-client --pipe test.sock list tools
+  $ mcp --pipe test.sock list tools
   Tools (10):
   - fs/write: Write content to a file. For OCaml files (.ml/.mli), automatically formats the code and returns diagnostics.
   - dune/build-status: Get the current build status from dune, including any errors or warnings
@@ -101,19 +101,19 @@ List available tools:
   - ocaml/eval: Evaluate OCaml expressions in project context
 
 Test calling ocaml/module-signature tool with List module:
-  $ mcp-client --pipe test.sock call ocaml/module-signature -a '{"module_path":["List"]}'
+  $ mcp --pipe test.sock call ocaml/module-signature -a '{"module_path":["List"]}'
   Could not find module List in build artifacts. Make sure the project is built with dune.
 
 Test calling non-existent tool:
-  $ mcp-client --pipe test.sock call nonexistent/tool 2>&1 | head -1
+  $ mcp --pipe test.sock call nonexistent/tool 2>&1 | head -1
   Fatal error: exception Failure("Request failed: JSON-RPC error")
 
 Test with invalid arguments for module-signature:
-  $ mcp-client --pipe test.sock call ocaml/module-signature -a '{"wrong_field":"value"}' 2>&1 | head -1
+  $ mcp --pipe test.sock call ocaml/module-signature -a '{"wrong_field":"value"}' 2>&1 | head -1
   Fatal error: exception Failure("Request failed: JSON-RPC error")
 
 Test with empty module path:
-  $ mcp-client --pipe test.sock call ocaml/module-signature -a '{"module_path":[]}' 
+  $ mcp --pipe test.sock call ocaml/module-signature -a '{"module_path":[]}'
   Could not find module  in build artifacts. Make sure the project is built with dune.
 
 Kill the server


### PR DESCRIPTION
This is how it is referred to in tests (which are otherwise broken).
E.g.
```diff
--- a/_build/.sandbox/1acf010634e80cc5a6d6bcac06e8cb2c/default/test/http.t/run.t
+++ b/_build/.sandbox/1acf010634e80cc5a6d6bcac06e8cb2c/default/test/http.t/run.t.corrected
@@ -7,25 +7,13 @@ Start the HTTP server:

 Test server info:
   $ mcp-client --socket 8080 info
-  Server: ocaml-mcp-server v0.1.0
-
-  Capabilities:
-  - Tools
-  - Logging
+  mcp-client: command not found
+  [127]
```