### PR TITLE
fix: add missing dependency to mcp.opam

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -20,7 +20,7 @@
  (synopsis "Model Context Protocol implementation for OCaml")
  (description
   "An OCaml implementation of the Model Context Protocol (MCP), providing both client and server libraries")
- (depends ocaml jsonrpc yojson ppx_deriving_yojson logs)
+ (depends ocaml jsonrpc jsonschema yojson ppx_deriving_yojson logs)
  (tags
   (mcp protocol rpc)))
 

--- a/mcp.opam
+++ b/mcp.opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml"
   "jsonrpc"
   "yojson"
+  "jsonschema"
   "ppx_deriving_yojson"
   "logs"
   "odoc" {with-doc}


### PR DESCRIPTION
# Info

Platform: MacOS arm64
OCaml: 5.3.0
OPAM: 2.3.0
Shell: zsh
Branch/Commit: main @ c93df296fea18742070a45e8c1ce21b02494e772

# Error

```
#=== ERROR while compiling mcp.dev ============================================#
# context     2.3.0 | macos/arm64 | ocaml.5.3.0 | pinned(git+file:///Users/REDACTED/REDACTED/ocaml-mcp#main#c93df296fea18742070a45e8c1ce21b02494e772)
# path        ~/playground/ocaml-mcp/_opam/.opam-switch/build/mcp.dev
# command     ~/.opam/opam-init/hooks/sandbox.sh build dune build -p mcp -j 13 @install
# exit-code   1
# env-file    ~/.opam/log/mcp-95029-005e44.env
# output-file ~/.opam/log/mcp-95029-005e44.out
### output ###
# File "lib/mcp-sdk/dune", line 4, characters 19-29:
# 4 |  (libraries mcp re jsonschema unix logs logs.fmt)
#                        ^^^^^^^^^^
# Error: Library "jsonschema" not found.
# -> required by library "mcp.sdk" in _build/default/lib/mcp-sdk
# -> required by _build/default/META.mcp
# -> required by _build/install/default/lib/mcp/META
# -> required by _build/default/mcp.install
# -> required by alias install
```

# How to reproduce

1. Checkout repo
2. No active opam switch
3. `opam switch create .`
4. See above

# Fix

1. Add missing dep in `.opam` file

# Notes

@tmattio I also added it to the dune-project file, this might be wrong. I will amend this, if it's unnecessary.