### PR TITLE
Fixed JSON Serialization for requestId (and progressToken)

### DIFF
--- a/bin/mcp_client.ml
+++ b/bin/mcp_client.ml
@@ -38,9 +38,9 @@ let connect ~sw ~connection ~config =
   let handler : Mcp.Client.notification_handler =
     {
       on_resources_updated = (fun _ -> ());
-      on_resources_list_changed = (fun () -> ());
-      on_prompts_list_changed = (fun () -> ());
-      on_tools_list_changed = (fun () -> ());
+      on_resources_list_changed = (fun _ -> ());
+      on_prompts_list_changed = (fun _ -> ());
+      on_tools_list_changed = (fun _ -> ());
       on_message = (fun _ -> ());
     }
   in
@@ -170,13 +170,13 @@ let unsubscribe_resource t ~uri =
 let _ = (subscribe_resource, unsubscribe_resource)
 
 let list_tools t ?cursor () =
-  let json = request t (ToolsList { cursor }) in
+  let json = request t (ToolsList { cursor; meta = None }) in
   match Mcp.Request.Tools.List.result_of_yojson json with
   | Ok result -> result
   | Error msg -> failwith (Printf.sprintf "Failed to parse tools list: %s" msg)
 
 let call_tool t ~name ?arguments () =
-  let json = request t (ToolsCall { name; arguments }) in
+  let json = request t (ToolsCall { name; arguments; meta = None }) in
   match Mcp.Request.Tools.Call.result_of_yojson json with
   | Ok result -> result
   | Error msg ->
@@ -213,7 +213,7 @@ let get_prompt t ~name ?arguments () =
 let _ = get_prompt
 
 let set_log_level t ~level =
-  let _json = request t (LoggingSetLevel { level }) in
+  let _json = request t (LoggingSetLevel { level; meta = None }) in
   ()
 
 let set_notification_handler t handler = t.notification_handler <- Some handler

--- a/dune-project
+++ b/dune-project
@@ -20,7 +20,15 @@
  (synopsis "Model Context Protocol implementation for OCaml")
  (description
   "An OCaml implementation of the Model Context Protocol (MCP), providing both client and server libraries")
- (depends ocaml jsonrpc jsonschema yojson ppx_deriving_yojson logs re)
+ (depends
+  ocaml
+  jsonrpc
+  jsonschema
+  yojson
+  ppx_inline_test
+  ppx_deriving_yojson
+  logs
+  re)
  (tags
   (mcp protocol rpc)))
 

--- a/dune-project
+++ b/dune-project
@@ -20,7 +20,7 @@
  (synopsis "Model Context Protocol implementation for OCaml")
  (description
   "An OCaml implementation of the Model Context Protocol (MCP), providing both client and server libraries")
- (depends ocaml jsonrpc jsonschema yojson ppx_deriving_yojson logs)
+ (depends ocaml jsonrpc jsonschema yojson ppx_deriving_yojson logs re)
  (tags
   (mcp protocol rpc)))
 

--- a/examples/weather-server/weather_server.ml
+++ b/examples/weather-server/weather_server.ml
@@ -48,10 +48,11 @@ let () =
           Mcp.Request.Tools.Call.content =
             [
               Mcp.Types.Content.Text
-                { type_ = "text"; text = get_weather args.city };
+                { type_ = "text"; text = get_weather args.city; meta = None };
             ];
           is_error = None;
           structured_content = None;
+          meta = None;
         });
 
   (* Use stdio transport *)

--- a/lib/mcp-sdk/mcp_sdk.mli
+++ b/lib/mcp-sdk/mcp_sdk.mli
@@ -43,6 +43,9 @@ module Context : sig
       [progress] parameter indicates the current progress value, and [total]
       optionally indicates the total amount of work. If no progress token is
       available, this function does nothing. *)
+
+  val meta : t -> Yojson.Safe.t option
+  (** [meta t] returns the metadata object from the request, if provided. *)
 end
 
 (** Helper functions for creating tool results *)
@@ -256,6 +259,7 @@ module Client : sig
 
   val tools_list :
     t ->
+    ?meta:Yojson.Safe.t ->
     ((Mcp.Request.Tools.List.result, string) result -> unit) ->
     outgoing_message
   (** [tools_list t callback] prepares a request to list available tools. *)
@@ -265,6 +269,7 @@ module Client : sig
     name:string ->
     args:'args ->
     args_to_yojson:('args -> Yojson.Safe.t) ->
+    ?meta:Yojson.Safe.t ->
     ((Mcp.Request.Tools.Call.result, string) result -> unit) ->
     outgoing_message
   (** [tools_call t ~name ~args ~args_to_yojson callback] prepares a request to
@@ -273,6 +278,7 @@ module Client : sig
 
   val resources_list :
     t ->
+    ?meta:Yojson.Safe.t ->
     ((Mcp.Request.Resources.List.result, string) result -> unit) ->
     outgoing_message
   (** [resources_list t callback] prepares a request to list resources. *)
@@ -280,12 +286,14 @@ module Client : sig
   val resources_read :
     t ->
     uri:string ->
+    ?meta:Yojson.Safe.t ->
     ((Mcp.Request.Resources.Read.result, string) result -> unit) ->
     outgoing_message
   (** [resources_read t ~uri callback] prepares a request to read a resource. *)
 
   val prompts_list :
     t ->
+    ?meta:Yojson.Safe.t ->
     ((Mcp.Request.Prompts.List.result, string) result -> unit) ->
     outgoing_message
   (** [prompts_list t callback] prepares a request to list prompts. *)
@@ -295,6 +303,7 @@ module Client : sig
     name:string ->
     args:'args ->
     args_to_yojson:('args -> Yojson.Safe.t) ->
+    ?meta:Yojson.Safe.t ->
     ((Mcp.Request.Prompts.Get.result, string) result -> unit) ->
     outgoing_message
   (** [prompts_get t ~name ~args ~args_to_yojson callback] prepares a request to

--- a/lib/mcp/dune
+++ b/lib/mcp/dune
@@ -1,6 +1,6 @@
 (library
  (name mcp)
  (public_name mcp)
- (libraries jsonrpc yojson ppx_deriving_yojson.runtime)
+ (libraries jsonrpc yojson ppx_deriving_yojson.runtime re)
  (preprocess
   (pps ppx_deriving_yojson)))

--- a/lib/mcp/dune
+++ b/lib/mcp/dune
@@ -2,5 +2,6 @@
  (name mcp)
  (public_name mcp)
  (libraries jsonrpc yojson ppx_deriving_yojson.runtime re)
+ (inline_tests)
  (preprocess
-  (pps ppx_deriving_yojson)))
+  (pps ppx_inline_test ppx_deriving_yojson)))

--- a/lib/mcp/mcp.ml
+++ b/lib/mcp/mcp.ml
@@ -6,3 +6,4 @@ module Notification = Mcp_notification
 module Protocol = Mcp_protocol
 module Server = Mcp_server
 module Client = Mcp_client
+module Meta = Mcp_meta

--- a/lib/mcp/mcp.mli
+++ b/lib/mcp/mcp.mli
@@ -31,3 +31,6 @@ module Server = Mcp_server
 
 module Client = Mcp_client
 (** Client implementation for connecting to MCP servers. *)
+
+module Meta = Mcp_meta
+(** Validator for _meta field keys. *)

--- a/lib/mcp/mcp_client.ml
+++ b/lib/mcp/mcp_client.ml
@@ -71,12 +71,12 @@ let handle_notification (client : t) (notification : Notification.t) : unit =
   match notification with
   | Notification.ResourcesUpdated params ->
       client.notification_handler.on_resources_updated params
-  | Notification.ResourcesListChanged ->
-      client.notification_handler.on_resources_list_changed ()
-  | Notification.PromptsListChanged ->
-      client.notification_handler.on_prompts_list_changed ()
-  | Notification.ToolsListChanged ->
-      client.notification_handler.on_tools_list_changed ()
+  | Notification.ResourcesListChanged params ->
+      client.notification_handler.on_resources_list_changed params
+  | Notification.PromptsListChanged params ->
+      client.notification_handler.on_prompts_list_changed params
+  | Notification.ToolsListChanged params ->
+      client.notification_handler.on_tools_list_changed params
   | Notification.Message params -> client.notification_handler.on_message params
   | _ -> () (* Client doesn't handle other notifications *)
 
@@ -113,8 +113,8 @@ let handle_request (client : t) (id : Jsonrpc.Id.t) (request : Request.t) :
         | Request.ElicitationCreate params ->
             handler.on_elicitation_create params
             |> Result.map Request.Elicitation.Create.result_to_yojson
-        | Request.RootsList ->
-            handler.on_roots_list ()
+        | Request.RootsList params ->
+            handler.on_roots_list params
             |> Result.map Request.Roots.List.result_to_yojson
         | _ -> Error "Client does not handle this request type"
       in
@@ -225,7 +225,7 @@ let prompts_get (client : t) ~name ?arguments
 let tools_list (client : t) ?cursor
     (callback : (Request.Tools.List.result, string) result -> unit) :
     outgoing_message =
-  let params = { Request.Tools.List.cursor } in
+  let params = { Request.Tools.List.cursor; meta = None } in
   send_request client (Request.ToolsList params) (fun response ->
       match response with
       | Ok json -> (
@@ -237,7 +237,7 @@ let tools_list (client : t) ?cursor
 let tools_call (client : t) ~name ?arguments
     (callback : (Request.Tools.Call.result, string) result -> unit) :
     outgoing_message =
-  let params = { Request.Tools.Call.name; arguments } in
+  let params = { Request.Tools.Call.name; arguments; meta = None } in
   send_request client (Request.ToolsCall params) (fun response ->
       match response with
       | Ok json -> (

--- a/lib/mcp/mcp_client.ml
+++ b/lib/mcp/mcp_client.ml
@@ -174,10 +174,10 @@ let get_server_info (client : t) : ServerInfo.t option = client.server_info
 
 (* Convenience functions for making requests *)
 
-let resources_list (client : t) ?cursor
+let resources_list (client : t) ?cursor ?meta
     (callback : (Request.Resources.List.result, string) result -> unit) :
     outgoing_message =
-  let params = { Request.Resources.List.cursor } in
+  let params = { Request.Resources.List.cursor; meta } in
   send_request client (Request.ResourcesList params) (fun response ->
       match response with
       | Ok json -> (
@@ -186,10 +186,10 @@ let resources_list (client : t) ?cursor
           | Error e -> callback (Error e))
       | Error err -> callback (Error err.message))
 
-let resources_read (client : t) ~uri
+let resources_read (client : t) ~uri ?meta
     (callback : (Request.Resources.Read.result, string) result -> unit) :
     outgoing_message =
-  let params = { Request.Resources.Read.uri } in
+  let params = { Request.Resources.Read.uri; meta } in
   send_request client (Request.ResourcesRead params) (fun response ->
       match response with
       | Ok json -> (
@@ -198,10 +198,10 @@ let resources_read (client : t) ~uri
           | Error e -> callback (Error e))
       | Error err -> callback (Error err.message))
 
-let prompts_list (client : t) ?cursor
+let prompts_list (client : t) ?cursor ?meta
     (callback : (Request.Prompts.List.result, string) result -> unit) :
     outgoing_message =
-  let params = { Request.Prompts.List.cursor } in
+  let params = { Request.Prompts.List.cursor; meta } in
   send_request client (Request.PromptsList params) (fun response ->
       match response with
       | Ok json -> (
@@ -210,10 +210,10 @@ let prompts_list (client : t) ?cursor
           | Error e -> callback (Error e))
       | Error err -> callback (Error err.message))
 
-let prompts_get (client : t) ~name ?arguments
+let prompts_get (client : t) ~name ?arguments ?meta
     (callback : (Request.Prompts.Get.result, string) result -> unit) :
     outgoing_message =
-  let params = { Request.Prompts.Get.name; arguments } in
+  let params = { Request.Prompts.Get.name; arguments; meta } in
   send_request client (Request.PromptsGet params) (fun response ->
       match response with
       | Ok json -> (
@@ -222,10 +222,10 @@ let prompts_get (client : t) ~name ?arguments
           | Error e -> callback (Error e))
       | Error err -> callback (Error err.message))
 
-let tools_list (client : t) ?cursor
+let tools_list (client : t) ?cursor ?meta
     (callback : (Request.Tools.List.result, string) result -> unit) :
     outgoing_message =
-  let params = { Request.Tools.List.cursor; meta = None } in
+  let params = { Request.Tools.List.cursor; meta } in
   send_request client (Request.ToolsList params) (fun response ->
       match response with
       | Ok json -> (
@@ -234,10 +234,10 @@ let tools_list (client : t) ?cursor
           | Error e -> callback (Error e))
       | Error err -> callback (Error err.message))
 
-let tools_call (client : t) ~name ?arguments
+let tools_call (client : t) ~name ?arguments ?meta
     (callback : (Request.Tools.Call.result, string) result -> unit) :
     outgoing_message =
-  let params = { Request.Tools.Call.name; arguments; meta = None } in
+  let params = { Request.Tools.Call.name; arguments; meta } in
   send_request client (Request.ToolsCall params) (fun response ->
       match response with
       | Ok json -> (

--- a/lib/mcp/mcp_client.mli
+++ b/lib/mcp/mcp_client.mli
@@ -92,6 +92,7 @@ val get_server_info : t -> ServerInfo.t option
 val resources_list :
   t ->
   ?cursor:cursor ->
+  ?meta:Yojson.Safe.t ->
   ((Mcp_request.Resources.List.result, string) result -> unit) ->
   outgoing_message
 (** [resources_list t ?cursor callback] lists available resources.
@@ -101,6 +102,7 @@ val resources_list :
 val resources_read :
   t ->
   uri:string ->
+  ?meta:Yojson.Safe.t ->
   ((Mcp_request.Resources.Read.result, string) result -> unit) ->
   outgoing_message
 (** [resources_read t ~uri callback] reads resource contents. *)
@@ -108,6 +110,7 @@ val resources_read :
 val prompts_list :
   t ->
   ?cursor:cursor ->
+  ?meta:Yojson.Safe.t ->
   ((Mcp_request.Prompts.List.result, string) result -> unit) ->
   outgoing_message
 (** [prompts_list t ?cursor callback] lists available prompts.
@@ -118,6 +121,7 @@ val prompts_get :
   t ->
   name:string ->
   ?arguments:(string * string) list ->
+  ?meta:Yojson.Safe.t ->
   ((Mcp_request.Prompts.Get.result, string) result -> unit) ->
   outgoing_message
 (** [prompts_get t ~name ?arguments callback] retrieves prompt with arguments.
@@ -126,6 +130,7 @@ val prompts_get :
 val tools_list :
   t ->
   ?cursor:cursor ->
+  ?meta:Yojson.Safe.t ->
   ((Mcp_request.Tools.List.result, string) result -> unit) ->
   outgoing_message
 (** [tools_list t ?cursor callback] lists available tools.
@@ -136,6 +141,7 @@ val tools_call :
   t ->
   name:string ->
   ?arguments:Yojson.Safe.t ->
+  ?meta:Yojson.Safe.t ->
   ((Mcp_request.Tools.Call.result, string) result -> unit) ->
   outgoing_message
 (** [tools_call t ~name ?arguments callback] invokes tool with arguments. *)

--- a/lib/mcp/mcp_meta.ml
+++ b/lib/mcp/mcp_meta.ml
@@ -1,83 +1,179 @@
 (** Validator for MCP _meta field keys. *)
 
-let label_re = Re.Perl.compile_pat "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+(* SPEC: "Labels MUST start with a letter and end with a letter or digit; interior characters can be letters, digits, or hyphens (-)." *)
+let is_valid_label s =
+  let label_re = Re.Perl.compile_pat "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$" in
+  Re.execp label_re s
 
-let name_re =
-  Re.compile
-    (Re.seq
-       [
-         Re.bos;
-         Re.alt [ Re.rg 'a' 'z'; Re.rg 'A' 'Z'; Re.rg '0' '9' ];
-         Re.opt
-           (Re.seq
-              [
-                Re.rep1
-                  (Re.alt
-                     [
-                       Re.char '-';
-                       Re.char '_';
-                       Re.char '.';
-                       Re.rg 'a' 'z';
-                       Re.rg 'A' 'Z';
-                       Re.rg '0' '9';
-                     ]);
-                Re.alt [ Re.rg 'a' 'z'; Re.rg 'A' 'Z'; Re.rg '0' '9' ];
-              ]);
-         Re.eos;
-       ])
+let%test "label start with letter" =
+  let valid_starts = [ "a"; "A" ] in
+  let invalid_starts = [ "1"; "-"; "_"; "." ] in
+  List.for_all is_valid_label valid_starts
+  && List.for_all (fun s -> not (is_valid_label s)) invalid_starts
 
-let mcp_reserved_prefix_re =
-  Re.compile
-    (Re.seq
-       [
-         Re.rep Re.any;
-         Re.alt [ Re.str "modelcontextprotocol"; Re.str "mcp" ];
-         Re.char '.';
-         Re.rep Re.any;
-         Re.char '/';
-       ])
+let%test "label end with letter or digit" =
+  let prefix = "valid" in
+  let construct = fun s -> prefix ^ s in
+  let valid_ends = List.map construct [ "z"; "Z"; "9" ] in
+  let invalid_ends = List.map construct [ "-"; "_"; "." ] in
+  List.for_all is_valid_label valid_ends
+  && List.for_all (fun s -> not (is_valid_label s)) invalid_ends
 
-let is_valid_label s = Re.execp label_re s
-let is_valid_name s = s = "" || Re.execp name_re s
-let is_mcp_reserved_prefix s = Re.execp mcp_reserved_prefix_re s
+let%test "label interior chars letter, dig, or hyphen" =
+  let prefix = "valid" in
+  let postfix = "end" in
+  let construct = fun s -> prefix ^ s ^ postfix in
+  let valid_interior = List.map construct [ "a"; "A"; "0"; "-" ] in
+  let invalid_interior = List.map construct [ "_"; "." ] in
+  List.for_all (fun s -> is_valid_label s) valid_interior
+  && List.for_all (fun s -> not (is_valid_label s)) invalid_interior
 
+(* SPEC: "If specified, MUST be a series of labels separated by dots (.), followed by a slash (/)." *)
+let prefix_labels str =
+  let label_strs = String.split_on_char '.' str in
+  List.fold_right
+    (fun h acc ->
+      (* If the label is valid, accumulate it; otherwise, return an error. *)
+      Result.bind acc (fun acc ->
+          if is_valid_label h then Ok (h :: acc)
+          else Error (Printf.sprintf "Invalid label: '%s' in prefix: %s" h str)))
+    label_strs (Ok [])
+
+let%test "prefix matches single valid label" =
+  Result.is_ok (prefix_labels "valid-label")
+
+let%test "prefix does not match invalid label" =
+  Result.is_error (prefix_labels "invalid-label-")
+
+let%test "prefix matches N valid labels" =
+  Result.is_ok (prefix_labels "valid1.valid2.valid3")
+
+let%test "prefix does not match invalid label in N labels" =
+  Result.is_error (prefix_labels "valid1.invalid-label-.valid3")
+
+(* SPEC: "Any prefix beginning with zero or more valid labels, followed by modelcontextprotocol or mcp, followed by any valid label, is reserved for MCP use." *)
+let is_reserved_prefix labels =
+  let len = List.length labels in
+  if len < 2 then false
+  else
+    let reserved_keys = [ "modelcontextprotocol"; "mcp" ] in
+    (* essentially, the spec says that [ ... , reserved_label , ANY ] is reserved *)
+    let check_key = List.nth labels (len - 2) in
+    List.mem check_key reserved_keys
+
+let is_mcp_reserved_prefix str =
+  match prefix_labels str with
+  | Ok labels -> is_reserved_prefix labels
+  | Error _ -> false
+
+(* SPEC: "For example: modelcontextprotocol.io/, mcp.dev/, api.modelcontextprotocol.org/, and tools.mcp.com/ are all reserved." *)
+let%test "is_reserved_prefix MCP spec tests" =
+  let spec_tests =
+    [
+      "modelcontextprotocol.io";
+      "mcp.dev";
+      "api.modelcontextprotocol.org";
+      "tools.mcp.com";
+    ]
+  in
+  List.for_all is_mcp_reserved_prefix spec_tests
+
+let%test "is_reserved_prefix not reserved spec tests" =
+  let not_spec_tests = [ "normal-prefix"; "mcp.two.labels" ] in
+  (* ¬∃ == ∀¬ *)
+  not (List.exists is_mcp_reserved_prefix not_spec_tests)
+
+(* SPEC: "Unless empty, MUST begin and end with an alphanumeric character ([a-z0-9A-Z]).
+MAY contain hyphens (-), underscores (_), dots (.), and alphanumerics in between." *)
+let is_valid_name s =
+  let name_re =
+    Re.Perl.compile_pat "^[a-zA-Z0-9]([-_.a-zA-Z0-9]*[a-zA-Z0-9])?$"
+  in
+  s = "" || Re.execp name_re s
+
+let%test "valid name tests" =
+  let valid_names =
+    [ ""; "valid"; "valid-Name"; "valid_Name"; "valid.Name"; "A" ]
+  in
+  List.for_all is_valid_name valid_names
+
+let%test "valid name tests with invalid" =
+  let invalid_names =
+    [
+      "-invalid";
+      "_invalid";
+      ".invalid";
+      "invalid-";
+      "invalid_";
+      "invalid.";
+      "in/valid";
+    ]
+  in
+  List.for_all (fun s -> not (is_valid_name s)) invalid_names
+
+(* SPEC: "Key name format: valid _meta key names have two segments: an optional prefix, and a name.
+If specified, MUST be a series of labels separated by dots (.), followed by a slash (/)."
+*)
 let validate_key key =
   match String.split_on_char '/' key with
   | [ name ] ->
       if is_valid_name name then Ok ()
       else Error (Printf.sprintf "Invalid _meta key name: '%s'" key)
   | [ prefix_part; name ] ->
-      if not (is_valid_label name) then
+      if not (is_valid_name name) then
         Error (Printf.sprintf "Invalid _meta key name segment: '%s'" name)
-      else if is_mcp_reserved_prefix (key ^ "/") then
-        Error
-          (Printf.sprintf "Using a reserved MCP prefix is not allowed: '%s'" key)
       else
-        let labels = String.split_on_char '.' prefix_part in
-        if List.for_all is_valid_label labels then Ok ()
-        else Error (Printf.sprintf "Invalid _meta key prefix: '%s'" prefix_part)
+        Result.bind (prefix_labels prefix_part) (fun labels ->
+            if is_reserved_prefix labels then
+              Error
+                (Printf.sprintf
+                   "Using a reserved MCP prefix is not allowed: '%s'" key)
+            else Ok ())
   | _ -> Error (Printf.sprintf "Invalid _meta key format: '%s'" key)
 
-let rec validate_json (json : Yojson.Safe.t) : (unit, string) result =
+let%test "validate_key tests" =
+  let prefix = "valid" in
+  let postfix = "end" in
+  let join_prefixes = fun s -> prefix ^ s ^ postfix in
+  let valid_prefixes = List.map join_prefixes [ "a"; "A"; "0"; "-" ] in
+  let invalid_prefixes = List.map join_prefixes [ "_"; "/"; ":" ] in
+  let valid_names =
+    [ ""; "valid"; "valid-Name"; "valid_Name"; "valid.Name"; "A" ]
+  in
+  let invalid_names =
+    [ "-invalid"; "_invalid"; ".invalid"; "invalid-"; "invalid_"; "invalid." ]
+  in
+  let cross pref name =
+    List.map (fun x -> List.map (fun y -> x ^ "/" ^ y) name) pref
+    |> List.flatten
+  in
+  let poorly_joined pref name =
+    List.map (fun x -> List.map (fun y -> x ^ "//" ^ y) name) pref
+    |> List.flatten
+  in
+  let valid_keys = cross valid_prefixes valid_names @ valid_names in
+  let invalid_keys =
+    cross invalid_prefixes invalid_names
+    @ cross valid_prefixes invalid_names
+    @ cross invalid_prefixes valid_names
+    @ poorly_joined valid_prefixes valid_names
+  in
+  List.for_all (fun k -> Result.is_ok (validate_key k)) valid_keys
+  && List.for_all (fun k -> Result.is_error (validate_key k)) invalid_keys
+
+(* SPEC: "The _meta property/parameter is reserved by MCP to allow clients and servers to attach additional metadata to their interactions.
+Certain key names are reserved by MCP for protocol-level metadata, as specified below; implementations MUST NOT make assumptions about values at these keys.
+Additionally, definitions in the schema may reserve particular names for purpose-specific metadata, as declared in those definitions.
+Key name format: valid _meta key names have two segments: an optional prefix, and a name."
+*)
+let validate_meta_json (json : Yojson.Safe.t) : (unit, string) result =
+  (* All keys must be valid _meta.<key> *)
   match json with
   | `Assoc items ->
       List.fold_left
-        (fun acc (key, value) ->
-          match acc with
-          | Error _ -> acc
-          | Ok () -> (
-              match validate_key key with
-              | Error e -> Error e
-              | Ok () -> validate_json value))
+        (fun acc (key, _) -> Result.bind acc (fun _ -> validate_key key))
         (Ok ()) items
-  | `List items ->
-      List.fold_left
-        (fun acc value ->
-          match acc with Error _ -> acc | Ok () -> validate_json value)
-        (Ok ()) items
-  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `String _ | `Null -> Ok ()
-  | `Tuple _ | `Variant _ ->
-      Error "Tuples and variants are not supported in _meta"
+  | _ -> Error "Only JSON objects are valid _meta"
 
 let validate (meta_option : Yojson.Safe.t option) : (unit, string) result =
-  match meta_option with None -> Ok () | Some json -> validate_json json
+  match meta_option with None -> Ok () | Some json -> validate_meta_json json

--- a/lib/mcp/mcp_meta.ml
+++ b/lib/mcp/mcp_meta.ml
@@ -1,0 +1,83 @@
+(** Validator for MCP _meta field keys. *)
+
+let label_re = Re.Perl.compile_pat "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+
+let name_re =
+  Re.compile
+    (Re.seq
+       [
+         Re.bos;
+         Re.alt [ Re.rg 'a' 'z'; Re.rg 'A' 'Z'; Re.rg '0' '9' ];
+         Re.opt
+           (Re.seq
+              [
+                Re.rep1
+                  (Re.alt
+                     [
+                       Re.char '-';
+                       Re.char '_';
+                       Re.char '.';
+                       Re.rg 'a' 'z';
+                       Re.rg 'A' 'Z';
+                       Re.rg '0' '9';
+                     ]);
+                Re.alt [ Re.rg 'a' 'z'; Re.rg 'A' 'Z'; Re.rg '0' '9' ];
+              ]);
+         Re.eos;
+       ])
+
+let mcp_reserved_prefix_re =
+  Re.compile
+    (Re.seq
+       [
+         Re.rep Re.any;
+         Re.alt [ Re.str "modelcontextprotocol"; Re.str "mcp" ];
+         Re.char '.';
+         Re.rep Re.any;
+         Re.char '/';
+       ])
+
+let is_valid_label s = Re.execp label_re s
+let is_valid_name s = s = "" || Re.execp name_re s
+let is_mcp_reserved_prefix s = Re.execp mcp_reserved_prefix_re s
+
+let validate_key key =
+  match String.split_on_char '/' key with
+  | [ name ] ->
+      if is_valid_name name then Ok ()
+      else Error (Printf.sprintf "Invalid _meta key name: '%s'" key)
+  | [ prefix_part; name ] ->
+      if not (is_valid_name name) then
+        Error (Printf.sprintf "Invalid _meta key name segment: '%s'" name)
+      else if is_mcp_reserved_prefix (key ^ "/") then
+        Error
+          (Printf.sprintf "Using a reserved MCP prefix is not allowed: '%s'" key)
+      else
+        let labels = String.split_on_char '.' prefix_part in
+        if List.for_all is_valid_label labels then Ok ()
+        else Error (Printf.sprintf "Invalid _meta key prefix: '%s'" prefix_part)
+  | _ -> Error (Printf.sprintf "Invalid _meta key format: '%s'" key)
+
+let rec validate_json (json : Yojson.Safe.t) : (unit, string) result =
+  match json with
+  | `Assoc items ->
+      List.fold_left
+        (fun acc (key, value) ->
+          match acc with
+          | Error _ -> acc
+          | Ok () -> (
+              match validate_key key with
+              | Error e -> Error e
+              | Ok () -> validate_json value))
+        (Ok ()) items
+  | `List items ->
+      List.fold_left
+        (fun acc value ->
+          match acc with Error _ -> acc | Ok () -> validate_json value)
+        (Ok ()) items
+  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `String _ | `Null -> Ok ()
+  | `Tuple _ | `Variant _ ->
+      Error "Tuples and variants are not supported in _meta"
+
+let validate (meta_option : Yojson.Safe.t option) : (unit, string) result =
+  match meta_option with None -> Ok () | Some json -> validate_json json

--- a/lib/mcp/mcp_meta.ml
+++ b/lib/mcp/mcp_meta.ml
@@ -47,7 +47,7 @@ let validate_key key =
       if is_valid_name name then Ok ()
       else Error (Printf.sprintf "Invalid _meta key name: '%s'" key)
   | [ prefix_part; name ] ->
-      if not (is_valid_name name) then
+      if not (is_valid_label name) then
         Error (Printf.sprintf "Invalid _meta key name segment: '%s'" name)
       else if is_mcp_reserved_prefix (key ^ "/") then
         Error

--- a/lib/mcp/mcp_meta.mli
+++ b/lib/mcp/mcp_meta.mli
@@ -1,0 +1,13 @@
+(** Validator for MCP _meta field keys.
+
+    This module enforces the key naming rules for the `_meta` field as defined
+    in the MCP specification. *)
+
+val validate : Yojson.Safe.t option -> (unit, string) result
+(** [validate meta_option] checks if the keys in the given JSON object conform
+    to the MCP specification for `_meta` fields.
+
+    @param meta_option The optional `_meta` field from a request or response.
+    @return
+      [Ok ()] if all keys are valid, or [Error reason] if a validation error
+      occurs. *)

--- a/lib/mcp/mcp_notification.ml
+++ b/lib/mcp/mcp_notification.ml
@@ -1,7 +1,7 @@
 open Mcp_types
 
 module Initialized = struct
-  type params = unit [@@deriving yojson]
+  type params = OnlyMetaParams.t [@@deriving yojson { strict = false }]
 end
 
 module Progress = struct
@@ -10,7 +10,7 @@ module Progress = struct
     progress : float;
     total : float option; [@default None]
   }
-  [@@deriving yojson]
+  [@@deriving yojson { strict = false }]
 end
 
 module Cancelled = struct
@@ -18,34 +18,34 @@ module Cancelled = struct
     request_id : request_id; [@key "requestId"]
     reason : string option; [@default None]
   }
-  [@@deriving yojson]
+  [@@deriving yojson { strict = false }]
 end
 
 module Resources = struct
   module Updated = struct
-    type params = { uri : string } [@@deriving yojson]
+    type params = { uri : string } [@@deriving yojson { strict = false }]
   end
 
   module ListChanged = struct
-    type params = unit [@@deriving yojson]
+    type params = OnlyMetaParams.t [@@deriving yojson { strict = false }]
   end
 end
 
 module Prompts = struct
   module ListChanged = struct
-    type params = unit [@@deriving yojson]
+    type params = OnlyMetaParams.t [@@deriving yojson { strict = false }]
   end
 end
 
 module Tools = struct
   module ListChanged = struct
-    type params = unit [@@deriving yojson]
+    type params = OnlyMetaParams.t [@@deriving yojson { strict = false }]
   end
 end
 
 module Roots = struct
   module ListChanged = struct
-    type params = unit [@@deriving yojson]
+    type params = OnlyMetaParams.t [@@deriving yojson { strict = false }]
   end
 end
 
@@ -55,40 +55,40 @@ module Message = struct
     logger : string option; [@default None]
     data : Yojson.Safe.t;
   }
-  [@@deriving yojson]
+  [@@deriving yojson { strict = false }]
 end
 
 type t =
-  | Initialized
+  | Initialized of Initialized.params
   | Progress of Progress.params
   | Cancelled of Cancelled.params
   | ResourcesUpdated of Resources.Updated.params
-  | ResourcesListChanged
-  | PromptsListChanged
-  | ToolsListChanged
-  | RootsListChanged
+  | ResourcesListChanged of Resources.ListChanged.params
+  | PromptsListChanged of Prompts.ListChanged.params
+  | ToolsListChanged of Tools.ListChanged.params
+  | RootsListChanged of Roots.ListChanged.params
   | Message of Message.params
 
 let method_name = function
-  | Initialized -> "notifications/initialized"
+  | Initialized _ -> "notifications/initialized"
   | Progress _ -> "notifications/progress"
   | Cancelled _ -> "notifications/cancelled"
   | ResourcesUpdated _ -> "notifications/resources/updated"
-  | ResourcesListChanged -> "notifications/resources/list_changed"
-  | PromptsListChanged -> "notifications/prompts/list_changed"
-  | ToolsListChanged -> "notifications/tools/list_changed"
-  | RootsListChanged -> "notifications/roots/list_changed"
+  | ResourcesListChanged _ -> "notifications/resources/list_changed"
+  | PromptsListChanged _ -> "notifications/prompts/list_changed"
+  | ToolsListChanged _ -> "notifications/tools/list_changed"
+  | RootsListChanged _ -> "notifications/roots/list_changed"
   | Message _ -> "notifications/message"
 
 let to_yojson = function
-  | Initialized -> Initialized.params_to_yojson ()
+  | Initialized params -> Initialized.params_to_yojson params
   | Progress params -> Progress.params_to_yojson params
   | Cancelled params -> Cancelled.params_to_yojson params
   | ResourcesUpdated params -> Resources.Updated.params_to_yojson params
-  | ResourcesListChanged -> Resources.ListChanged.params_to_yojson ()
-  | PromptsListChanged -> Prompts.ListChanged.params_to_yojson ()
-  | ToolsListChanged -> Tools.ListChanged.params_to_yojson ()
-  | RootsListChanged -> Roots.ListChanged.params_to_yojson ()
+  | ResourcesListChanged params -> Resources.ListChanged.params_to_yojson params
+  | PromptsListChanged params -> Prompts.ListChanged.params_to_yojson params
+  | ToolsListChanged params -> Tools.ListChanged.params_to_yojson params
+  | RootsListChanged params -> Roots.ListChanged.params_to_yojson params
   | Message params -> Message.params_to_yojson params
 
 let of_jsonrpc (method_ : string) (params : Yojson.Safe.t option) :
@@ -97,7 +97,7 @@ let of_jsonrpc (method_ : string) (params : Yojson.Safe.t option) :
   match method_ with
   | "notifications/initialized" -> (
       match Initialized.params_of_yojson params with
-      | Ok () -> Ok Initialized
+      | Ok params -> Ok (Initialized params)
       | Error e -> Error e)
   | "notifications/progress" -> (
       match Progress.params_of_yojson params with
@@ -113,19 +113,19 @@ let of_jsonrpc (method_ : string) (params : Yojson.Safe.t option) :
       | Error e -> Error e)
   | "notifications/resources/list_changed" -> (
       match Resources.ListChanged.params_of_yojson params with
-      | Ok () -> Ok ResourcesListChanged
+      | Ok params -> Ok (ResourcesListChanged params)
       | Error e -> Error e)
   | "notifications/prompts/list_changed" -> (
       match Prompts.ListChanged.params_of_yojson params with
-      | Ok () -> Ok PromptsListChanged
+      | Ok params -> Ok (PromptsListChanged params)
       | Error e -> Error e)
   | "notifications/tools/list_changed" -> (
       match Tools.ListChanged.params_of_yojson params with
-      | Ok () -> Ok ToolsListChanged
+      | Ok params -> Ok (ToolsListChanged params)
       | Error e -> Error e)
   | "notifications/roots/list_changed" -> (
       match Roots.ListChanged.params_of_yojson params with
-      | Ok () -> Ok RootsListChanged
+      | Ok params -> Ok (RootsListChanged params)
       | Error e -> Error e)
   | "notifications/message" -> (
       match Message.params_of_yojson params with

--- a/lib/mcp/mcp_notification.mli
+++ b/lib/mcp/mcp_notification.mli
@@ -8,7 +8,7 @@ open Mcp_types
 
 (** Sent after successful initialization handshake. *)
 module Initialized : sig
-  type params = unit [@@deriving yojson]
+  type params = OnlyMetaParams.t [@@deriving yojson { strict = false }]
 end
 
 (** Progress updates for long-running operations. *)
@@ -18,25 +18,25 @@ module Progress : sig
     progress : float;
     total : float option;
   }
-  [@@deriving yojson]
+  [@@deriving yojson { strict = false }]
 end
 
 (** Request cancellation notification. *)
 module Cancelled : sig
   type params = { request_id : request_id; reason : string option }
-  [@@deriving yojson]
+  [@@deriving yojson { strict = false }]
 end
 
 (** Resource change notifications. *)
 module Resources : sig
   (** Specific resource content updated. *)
   module Updated : sig
-    type params = { uri : string } [@@deriving yojson]
+    type params = { uri : string } [@@deriving yojson { strict = false }]
   end
 
   (** Available resources list changed. *)
   module ListChanged : sig
-    type params = unit [@@deriving yojson]
+    type params = OnlyMetaParams.t [@@deriving yojson { strict = false }]
   end
 end
 
@@ -44,7 +44,7 @@ end
 module Prompts : sig
   (** Available prompts list changed. *)
   module ListChanged : sig
-    type params = unit [@@deriving yojson]
+    type params = OnlyMetaParams.t [@@deriving yojson { strict = false }]
   end
 end
 
@@ -52,7 +52,7 @@ end
 module Tools : sig
   (** Available tools list changed. *)
   module ListChanged : sig
-    type params = unit [@@deriving yojson]
+    type params = OnlyMetaParams.t [@@deriving yojson { strict = false }]
   end
 end
 
@@ -60,7 +60,7 @@ end
 module Roots : sig
   (** Root directories list changed. *)
   module ListChanged : sig
-    type params = unit [@@deriving yojson]
+    type params = OnlyMetaParams.t [@@deriving yojson { strict = false }]
   end
 end
 
@@ -71,18 +71,18 @@ module Message : sig
     logger : string option;
     data : Yojson.Safe.t;
   }
-  [@@deriving yojson]
+  [@@deriving yojson { strict = false }]
 end
 
 type t =
-  | Initialized
+  | Initialized of Initialized.params
   | Progress of Progress.params
   | Cancelled of Cancelled.params
   | ResourcesUpdated of Resources.Updated.params
-  | ResourcesListChanged
-  | PromptsListChanged
-  | ToolsListChanged
-  | RootsListChanged
+  | ResourcesListChanged of Resources.ListChanged.params
+  | PromptsListChanged of Prompts.ListChanged.params
+  | ToolsListChanged of Tools.ListChanged.params
+  | RootsListChanged of Roots.ListChanged.params
   | Message of Message.params
       (** Notification variants for all MCP notifications. *)
 

--- a/lib/mcp/mcp_request.mli
+++ b/lib/mcp/mcp_request.mli
@@ -13,7 +13,7 @@ module Initialize : sig
     capabilities : Capabilities.client;
     client_info : ClientInfo.t;
   }
-  [@@deriving yojson]
+  [@@deriving yojson { strict = false }]
   (** Initialization parameters with version and capabilities. *)
 
   type result = {
@@ -21,46 +21,60 @@ module Initialize : sig
     capabilities : Capabilities.server;
     server_info : ServerInfo.t;
     instructions : string option;
+    meta : Yojson.Safe.t option; [@default None] [@key "_meta"]
   }
-  [@@deriving yojson]
+  [@@deriving yojson { strict = false }]
   (** Initialization result with negotiated version and server info. *)
 end
 
 (** Resource discovery and reading. *)
 module Resources : sig
   module List : sig
-    type params = { cursor : cursor option } [@@deriving yojson]
+    type params = { cursor : cursor option }
+    [@@deriving yojson { strict = false }]
 
-    type result = { resources : Resource.t list; next_cursor : cursor option }
-    [@@deriving yojson]
+    type result = {
+      resources : Resource.t list;
+      next_cursor : cursor option;
+      meta : Yojson.Safe.t option; [@default None] [@key "_meta"]
+    }
+    [@@deriving yojson { strict = false }]
   end
 
   module Read : sig
-    type params = { uri : string } [@@deriving yojson]
+    type params = { uri : string } [@@deriving yojson { strict = false }]
 
-    type result = { contents : Content.resource_contents list }
-    [@@deriving yojson]
+    type result = {
+      contents : Content.resource_contents list;
+      meta : Yojson.Safe.t option; [@default None] [@key "_meta"]
+    }
+    [@@deriving yojson { strict = false }]
   end
 
   module Subscribe : sig
-    type params = { uri : string } [@@deriving yojson]
-    type result = unit [@@deriving yojson]
+    type params = { uri : string } [@@deriving yojson { strict = false }]
+    type result = unit [@@deriving yojson { strict = false }]
   end
 
   module Unsubscribe : sig
-    type params = { uri : string } [@@deriving yojson]
-    type result = unit [@@deriving yojson]
+    type params = { uri : string } [@@deriving yojson { strict = false }]
+    type result = unit [@@deriving yojson { strict = false }]
   end
 
   module Templates : sig
     module List : sig
-      type params = { cursor : cursor option } [@@deriving yojson]
+      type params = {
+        cursor : cursor option;
+        meta : Yojson.Safe.t option; [@default None] [@key "_meta"]
+      }
+      [@@deriving yojson { strict = false }]
 
       type result = {
         resource_templates : Resource.template list;
         next_cursor : cursor option;
+        meta : Yojson.Safe.t option; [@default None] [@key "_meta"]
       }
-      [@@deriving yojson]
+      [@@deriving yojson { strict = false }]
     end
   end
 end
@@ -68,10 +82,15 @@ end
 (** Prompt template management. *)
 module Prompts : sig
   module List : sig
-    type params = { cursor : cursor option } [@@deriving yojson]
+    type params = { cursor : cursor option }
+    [@@deriving yojson { strict = false }]
 
-    type result = { prompts : Prompt.t list; next_cursor : cursor option }
-    [@@deriving yojson]
+    type result = {
+      prompts : Prompt.t list;
+      next_cursor : cursor option;
+      meta : Yojson.Safe.t option; [@default None] [@key "_meta"]
+    }
+    [@@deriving yojson { strict = false }]
   end
 
   module Get : sig
@@ -83,30 +102,44 @@ module Prompts : sig
     type result = {
       description : string option;
       messages : Prompt.message list;
+      meta : Yojson.Safe.t option; [@default None] [@key "_meta"]
     }
-    [@@deriving yojson]
+    [@@deriving yojson { strict = false }]
   end
 end
 
 (** Tool discovery and invocation. *)
 module Tools : sig
   module List : sig
-    type params = { cursor : cursor option } [@@deriving yojson]
+    type params = {
+      cursor : cursor option; [@default None]
+      meta : Yojson.Safe.t option; [@default None] [@key "_meta"]
+    }
+    [@@deriving yojson { strict = false }]
 
-    type result = { tools : Tool.t list; next_cursor : cursor option }
-    [@@deriving yojson]
+    type result = {
+      tools : Tool.t list;
+      next_cursor : cursor option;
+      meta : Yojson.Safe.t option; [@default None] [@key "_meta"]
+    }
+    [@@deriving yojson { strict = false }]
   end
 
   module Call : sig
-    type params = { name : string; arguments : Yojson.Safe.t option }
-    [@@deriving yojson]
+    type params = {
+      name : string;
+      arguments : Yojson.Safe.t option;
+      meta : Yojson.Safe.t option; [@default None] [@key "_meta"]
+    }
+    [@@deriving yojson { strict = false }]
 
     type result = {
       content : Content.t list;
       is_error : bool option;
       structured_content : Yojson.Safe.t option;
+      meta : Yojson.Safe.t option; [@default None] [@key "_meta"]
     }
-    [@@deriving yojson]
+    [@@deriving yojson { strict = false }]
   end
 end
 
@@ -123,15 +156,16 @@ module Sampling : sig
       stop_sequences : string list option;
       metadata : Yojson.Safe.t option;
     }
-    [@@deriving yojson]
+    [@@deriving yojson { strict = false }]
 
     type result = {
       role : string;
       content : Content.t;
       model : string;
       stop_reason : string option;
+      meta : Yojson.Safe.t option; [@default None] [@key "_meta"]
     }
-    [@@deriving yojson]
+    [@@deriving yojson { strict = false }]
   end
 end
 
@@ -146,6 +180,7 @@ module Elicitation : sig
     type result = {
       action : string;
       content : (string * Yojson.Safe.t) list option;
+      meta : Yojson.Safe.t option; [@default None] [@key "_meta"]
     }
 
     val result_to_yojson : result -> Yojson.Safe.t
@@ -156,8 +191,13 @@ end
 (** Logging configuration. *)
 module Logging : sig
   module SetLevel : sig
-    type params = { level : LogLevel.t } [@@deriving yojson]
-    type result = unit [@@deriving yojson]
+    type params = {
+      level : LogLevel.t;
+      meta : Yojson.Safe.t option; [@default None] [@key "_meta"]
+    }
+    [@@deriving yojson { strict = false }]
+
+    type result = OnlyMetaParams.t [@@deriving yojson { strict = false }]
   end
 end
 
@@ -168,24 +208,33 @@ module Completion : sig
       ref_ : CompletionReference.t;
       argument : CompletionArgument.t;
     }
-    [@@deriving yojson]
+    [@@deriving yojson { strict = false }]
 
-    type result = Completion.t [@@deriving yojson]
+    type result = {
+      completion : Completion.t;
+      meta : Yojson.Safe.t option; [@default None] [@key "_meta"]
+    }
+    [@@deriving yojson { strict = false }]
   end
 end
 
 (** Root directory listing. *)
 module Roots : sig
   module List : sig
-    type params = unit [@@deriving yojson]
-    type result = { roots : Root.t list } [@@deriving yojson]
+    type params = OnlyMetaParams.t [@@deriving yojson { strict = false }]
+
+    type result = {
+      roots : Root.t list;
+      meta : Yojson.Safe.t option; [@default None] [@key "_meta"]
+    }
+    [@@deriving yojson { strict = false }]
   end
 end
 
 (** Connection keep-alive. *)
 module Ping : sig
-  type params = unit [@@deriving yojson]
-  type result = unit [@@deriving yojson]
+  type params = OnlyMetaParams.t [@@deriving yojson { strict = false }]
+  type result = unit [@@deriving yojson { strict = false }]
 end
 
 type t =
@@ -203,8 +252,8 @@ type t =
   | ElicitationCreate of Elicitation.Create.params
   | LoggingSetLevel of Logging.SetLevel.params
   | CompletionComplete of Completion.Complete.params
-  | RootsList
-  | Ping  (** Request variants for all MCP methods. *)
+  | RootsList of Roots.List.params
+  | Ping of Ping.params  (** Request variants for all MCP methods. *)
 
 val method_name : t -> string
 (** [method_name request] returns JSON-RPC method name. *)

--- a/lib/mcp/mcp_request.mli
+++ b/lib/mcp/mcp_request.mli
@@ -30,7 +30,10 @@ end
 (** Resource discovery and reading. *)
 module Resources : sig
   module List : sig
-    type params = { cursor : cursor option }
+    type params = {
+      cursor : cursor option;
+      meta : Yojson.Safe.t option; [@default None] [@key "_meta"]
+    }
     [@@deriving yojson { strict = false }]
 
     type result = {
@@ -42,7 +45,11 @@ module Resources : sig
   end
 
   module Read : sig
-    type params = { uri : string } [@@deriving yojson { strict = false }]
+    type params = {
+      uri : string;
+      meta : Yojson.Safe.t option; [@default None] [@key "_meta"]
+    }
+    [@@deriving yojson { strict = false }]
 
     type result = {
       contents : Content.resource_contents list;
@@ -52,12 +59,22 @@ module Resources : sig
   end
 
   module Subscribe : sig
-    type params = { uri : string } [@@deriving yojson { strict = false }]
+    type params = {
+      uri : string;
+      meta : Yojson.Safe.t option; [@default None] [@key "_meta"]
+    }
+    [@@deriving yojson { strict = false }]
+
     type result = unit [@@deriving yojson { strict = false }]
   end
 
   module Unsubscribe : sig
-    type params = { uri : string } [@@deriving yojson { strict = false }]
+    type params = {
+      uri : string;
+      meta : Yojson.Safe.t option; [@default None] [@key "_meta"]
+    }
+    [@@deriving yojson { strict = false }]
+
     type result = unit [@@deriving yojson { strict = false }]
   end
 
@@ -82,7 +99,10 @@ end
 (** Prompt template management. *)
 module Prompts : sig
   module List : sig
-    type params = { cursor : cursor option }
+    type params = {
+      cursor : cursor option;
+      meta : Yojson.Safe.t option; [@default None] [@key "_meta"]
+    }
     [@@deriving yojson { strict = false }]
 
     type result = {
@@ -94,7 +114,11 @@ module Prompts : sig
   end
 
   module Get : sig
-    type params = { name : string; arguments : (string * string) list option }
+    type params = {
+      name : string;
+      arguments : (string * string) list option;
+      meta : Yojson.Safe.t option; [@default None] [@key "_meta"]
+    }
 
     val params_to_yojson : params -> Yojson.Safe.t
     val params_of_yojson : Yojson.Safe.t -> (params, string) Stdlib.result
@@ -172,7 +196,11 @@ end
 (** User input elicitation. *)
 module Elicitation : sig
   module Create : sig
-    type params = { message : string; requested_schema : ElicitationSchema.t }
+    type params = {
+      message : string;
+      requested_schema : ElicitationSchema.t;
+      meta : Yojson.Safe.t option; [@default None] [@key "_meta"]
+    }
 
     val params_to_yojson : params -> Yojson.Safe.t
     val params_of_yojson : Yojson.Safe.t -> (params, string) Stdlib.result
@@ -207,6 +235,7 @@ module Completion : sig
     type params = {
       ref_ : CompletionReference.t;
       argument : CompletionArgument.t;
+      meta : Yojson.Safe.t option; [@default None] [@key "_meta"]
     }
     [@@deriving yojson { strict = false }]
 

--- a/lib/mcp/mcp_server.ml
+++ b/lib/mcp/mcp_server.ml
@@ -87,6 +87,7 @@ let handle_request (server : t) (id : Jsonrpc.Id.t) (request : Request.t) :
             capabilities = server.server_capabilities;
             server_info = server.server_info;
             instructions = None;
+            meta = None;
           }
         in
         match server.handler.on_initialize params with
@@ -165,26 +166,27 @@ let handle_request (server : t) (id : Jsonrpc.Id.t) (request : Request.t) :
           response_to_outgoing ~id (Request.CompletionComplete result)
       | Error msg ->
           error_to_outgoing ~id ~code:ErrorCode.internal_error ~message:msg ())
-  | Request.RootsList -> (
-      match server.handler.on_roots_list () with
+  | Request.RootsList params -> (
+      match server.handler.on_roots_list params with
       | Ok result -> response_to_outgoing ~id (Request.RootsList result)
       | Error msg ->
           error_to_outgoing ~id ~code:ErrorCode.internal_error ~message:msg ())
-  | Request.Ping -> (
-      match server.handler.on_ping () with
+  | Request.Ping params -> (
+      match server.handler.on_ping params with
       | Ok result -> response_to_outgoing ~id (Request.Ping result)
       | Error msg ->
           error_to_outgoing ~id ~code:ErrorCode.internal_error ~message:msg ())
 
 let handle_notification (server : t) (notification : Notification.t) : unit =
   match notification with
-  | Notification.Initialized -> server.notification_handler.on_initialized ()
+  | Notification.Initialized params ->
+      server.notification_handler.on_initialized params
   | Notification.Progress params ->
       server.notification_handler.on_progress params
   | Notification.Cancelled params ->
       server.notification_handler.on_cancelled params
-  | Notification.RootsListChanged ->
-      server.notification_handler.on_roots_list_changed ()
+  | Notification.RootsListChanged params ->
+      server.notification_handler.on_roots_list_changed params
   | _ -> () (* Server doesn't handle other notifications *)
 
 let handle_message (server : t) (msg : incoming_message) :

--- a/lib/mcp/mcp_types.ml
+++ b/lib/mcp/mcp_types.ml
@@ -8,8 +8,43 @@ module Protocol = struct
   let jsonrpc_version = "2.0"
 end
 
-type request_id = String of string | Int of int [@@deriving yojson]
-type progress_token = String of string | Int of int [@@deriving yojson]
+module String_or_int () = struct
+  type t = String of string | Int of int [@@deriving yojson]
+
+  let of_yojson = function
+    | `Int i -> Ok (Int i)
+    | `String s -> Ok (String s)
+    | json -> of_yojson json
+
+  let to_yojson = function String s -> `String s | Int i -> `Int i
+end
+
+include (
+  struct
+    module T = String_or_int ()
+
+    type request_id = T.t = String of string | Int of int
+
+    let request_id_of_yojson = T.of_yojson
+    let request_id_to_yojson = T.to_yojson
+  end :
+    sig
+      type request_id = String of string | Int of int [@@deriving yojson]
+    end)
+
+include (
+  struct
+    module T = String_or_int ()
+
+    type progress_token = T.t = String of string | Int of int
+
+    let progress_token_of_yojson = T.of_yojson
+    let progress_token_to_yojson = T.to_yojson
+  end :
+    sig
+      type progress_token = String of string | Int of int [@@deriving yojson]
+    end)
+
 type cursor = string [@@deriving yojson]
 
 module ErrorCode = struct

--- a/lib/mcp/mcp_types.mli
+++ b/lib/mcp/mcp_types.mli
@@ -62,14 +62,14 @@ type error = {
   message : string;
   data : Yojson.Safe.t option;
 }
-[@@deriving yojson]
+[@@deriving yojson { strict = false }]
 (** JSON-RPC error response. *)
 
-type meta = Yojson.Safe.t [@@deriving yojson]
-(** Arbitrary metadata as JSON. *)
-
-type 'a with_meta = { result : 'a; meta : meta option } [@@deriving yojson]
-(** Type with optional metadata. *)
+module OnlyMetaParams : sig
+  type t = { meta : Yojson.Safe.t option [@default None] [@key "_meta"] }
+  [@@deriving yojson { strict = false }]
+  (** Parameters that can be either unit, or only _meta. *)
+end
 
 (** Log severity levels. *)
 module LogLevel : sig
@@ -88,15 +88,30 @@ end
 
 (** Content types for messages and resources. *)
 module Content : sig
-  type text = { type_ : string; text : string } [@@deriving yojson]
+  type text = {
+    type_ : string;
+    text : string;
+    meta : Yojson.Safe.t option; [@default None] [@key "_meta"]
+  }
+  [@@deriving yojson { strict = false }]
   (** Text content with MIME type. *)
 
-  type image = { type_ : string; data : string; mime_type : string }
-  [@@deriving yojson]
+  type image = {
+    type_ : string;
+    data : string;
+    mime_type : string;
+    meta : Yojson.Safe.t option; [@default None] [@key "_meta"]
+  }
+  [@@deriving yojson { strict = false }]
   (** Base64-encoded image with MIME type. *)
 
-  type audio = { type_ : string; data : string; mime_type : string }
-  [@@deriving yojson]
+  type audio = {
+    type_ : string;
+    data : string;
+    mime_type : string;
+    meta : Yojson.Safe.t option; [@default None] [@key "_meta"]
+  }
+  [@@deriving yojson { strict = false }]
   (** Base64-encoded audio with MIME type. *)
 
   type resource_link = {
@@ -108,8 +123,9 @@ module Content : sig
     mime_type : string option;
     size : int option;
     annotations : Yojson.Safe.t option;
+    meta : Yojson.Safe.t option; [@default None] [@key "_meta"]
   }
-  [@@deriving yojson]
+  [@@deriving yojson { strict = false }]
   (** Reference to external resource. *)
 
   type resource_contents = {
@@ -117,12 +133,17 @@ module Content : sig
     mime_type : string option;
     text : string option;
     blob : string option;
+    meta : Yojson.Safe.t option; [@default None] [@key "_meta"]
   }
-  [@@deriving yojson]
+  [@@deriving yojson { strict = false }]
   (** Resource contents with either text or base64 blob. *)
 
-  type embedded_resource = { type_ : string; resource : resource_contents }
-  [@@deriving yojson]
+  type embedded_resource = {
+    type_ : string;
+    resource : resource_contents;
+    meta : Yojson.Safe.t option; [@default None] [@key "_meta"]
+  }
+  [@@deriving yojson { strict = false }]
   (** Inline resource with contents. *)
 
   (** Content variants for different media types. *)
@@ -132,7 +153,7 @@ module Content : sig
     | Audio of audio
     | ResourceLink of resource_link
     | EmbeddedResource of embedded_resource
-  [@@deriving yojson]
+  [@@deriving yojson { strict = false }]
 end
 
 (** Resource descriptions and templates. *)
@@ -145,8 +166,9 @@ module Resource : sig
     mime_type : string option;
     size : int option;
     annotations : Yojson.Safe.t option;
+    meta : Yojson.Safe.t option; [@default None] [@key "_meta"]
   }
-  [@@deriving yojson]
+  [@@deriving yojson { strict = false }]
   (** Resource with URI and metadata. *)
 
   type template = {
@@ -156,8 +178,9 @@ module Resource : sig
     description : string option;
     mime_type : string option;
     annotations : Yojson.Safe.t option;
+    meta : Yojson.Safe.t option; [@default None] [@key "_meta"]
   }
-  [@@deriving yojson]
+  [@@deriving yojson { strict = false }]
   (** Resource template with URI pattern. *)
 end
 
@@ -170,7 +193,7 @@ module Tool : sig
     idempotent : bool option;
     open_world : bool option;
   }
-  [@@deriving yojson]
+  [@@deriving yojson { strict = false }]
   (** Tool behavior annotations. *)
 
   type t = {
@@ -180,8 +203,9 @@ module Tool : sig
     input_schema : Yojson.Safe.t;
     output_schema : Yojson.Safe.t option;
     annotations : annotation option;
+    meta : Yojson.Safe.t option; [@default None] [@key "_meta"]
   }
-  [@@deriving yojson]
+  [@@deriving yojson { strict = false }]
   (** Tool with JSON Schema for input/output. *)
 end
 
@@ -193,7 +217,7 @@ module Prompt : sig
     description : string option;
     required : bool option;
   }
-  [@@deriving yojson]
+  [@@deriving yojson { strict = false }]
   (** Prompt argument specification. *)
 
   type t = {
@@ -201,27 +225,32 @@ module Prompt : sig
     title : string option;
     description : string option;
     arguments : argument list option;
+    meta : Yojson.Safe.t option; [@default None] [@key "_meta"]
   }
-  [@@deriving yojson]
+  [@@deriving yojson { strict = false }]
   (** Prompt template with arguments. *)
 
-  type message = { role : string; content : Content.t } [@@deriving yojson]
+  type message = { role : string; content : Content.t }
+  [@@deriving yojson { strict = false }]
   (** Message with role and content. *)
 end
 
 (** Client and server capabilities. *)
 module Capabilities : sig
-  type roots = { list_changed : bool option } [@@deriving yojson]
+  type roots = { list_changed : bool option }
+  [@@deriving yojson { strict = false }]
   (** Root directory change notifications. *)
 
-  type prompts = { list_changed : bool option } [@@deriving yojson]
+  type prompts = { list_changed : bool option }
+  [@@deriving yojson { strict = false }]
   (** Prompt list change notifications. *)
 
   type resources = { subscribe : bool option; list_changed : bool option }
-  [@@deriving yojson]
+  [@@deriving yojson { strict = false }]
   (** Resource subscription and change notifications. *)
 
-  type tools = { list_changed : bool option } [@@deriving yojson]
+  type tools = { list_changed : bool option }
+  [@@deriving yojson { strict = false }]
   (** Tool list change notifications. *)
 
   type client = {
@@ -230,7 +259,7 @@ module Capabilities : sig
     elicitation : Yojson.Safe.t option;
     roots : roots option;
   }
-  [@@deriving yojson]
+  [@@deriving yojson { strict = false }]
   (** Client-supported capabilities. *)
 
   type server = {
@@ -241,43 +270,52 @@ module Capabilities : sig
     resources : resources option;
     tools : tools option;
   }
-  [@@deriving yojson]
+  [@@deriving yojson { strict = false }]
   (** Server-supported capabilities. *)
 end
 
 (** Implementation information. *)
 module Implementation : sig
-  type t = { name : string; version : string } [@@deriving yojson]
+  type t = { name : string; version : string }
+  [@@deriving yojson { strict = false }]
   (** Implementation name and version. *)
 end
 
 (** Client information. *)
 module ClientInfo : sig
-  type t = { name : string; version : string } [@@deriving yojson]
+  type t = { name : string; version : string }
+  [@@deriving yojson { strict = false }]
   (** Client name and version. *)
 end
 
 (** Server information. *)
 module ServerInfo : sig
-  type t = { name : string; version : string } [@@deriving yojson]
+  type t = { name : string; version : string }
+  [@@deriving yojson { strict = false }]
   (** Server name and version. *)
 end
 
 (** Root directory information. *)
 module Root : sig
-  type t = { uri : string; name : string option } [@@deriving yojson]
+  type t = {
+    uri : string;
+    name : string option;
+    meta : Yojson.Safe.t option; [@default None] [@key "_meta"]
+  }
+  [@@deriving yojson { strict = false }]
   (** Root directory URI with optional name. *)
 end
 
 (** Sampling message for model interactions. *)
 module SamplingMessage : sig
-  type t = { role : string; content : Content.t } [@@deriving yojson]
+  type t = { role : string; content : Content.t }
+  [@@deriving yojson { strict = false }]
   (** Message with role and content for sampling. *)
 end
 
 (** Model hint for sampling. *)
 module ModelHint : sig
-  type t = { name : string option } [@@deriving yojson]
+  type t = { name : string option } [@@deriving yojson { strict = false }]
   (** Optional model name hint. *)
 end
 
@@ -289,13 +327,14 @@ module ModelPreferences : sig
     speed_priority : float option;
     intelligence_priority : float option;
   }
-  [@@deriving yojson]
+  [@@deriving yojson { strict = false }]
   (** Preferences for model selection with priority weights. *)
 end
 
 (** Completion argument specification. *)
 module CompletionArgument : sig
-  type t = { name : string; value : string } [@@deriving yojson]
+  type t = { name : string; value : string }
+  [@@deriving yojson { strict = false }]
   (** Named argument with value. *)
 end
 
@@ -303,13 +342,13 @@ end
 module CompletionReference : sig
   (** Reference to completable items by type and name. *)
   type t = Resource of string | ResourceTemplate of string | Prompt of string
-  [@@deriving yojson]
+  [@@deriving yojson { strict = false }]
 end
 
 (** Completion result with pagination. *)
 module Completion : sig
   type t = { values : string list; total : int option; has_more : bool option }
-  [@@deriving yojson]
+  [@@deriving yojson { strict = false }]
   (** Completion values with optional pagination info. *)
 end
 
@@ -323,7 +362,7 @@ module PrimitiveSchema : sig
     min_length : int option;
     max_length : int option;
   }
-  [@@deriving yojson]
+  [@@deriving yojson { strict = false }]
 
   type number_schema = {
     type_ : string;
@@ -332,7 +371,7 @@ module PrimitiveSchema : sig
     minimum : int option;
     maximum : int option;
   }
-  [@@deriving yojson]
+  [@@deriving yojson { strict = false }]
 
   type boolean_schema = {
     type_ : string;
@@ -340,7 +379,7 @@ module PrimitiveSchema : sig
     description : string option;
     default : bool option;
   }
-  [@@deriving yojson]
+  [@@deriving yojson { strict = false }]
 
   type enum_schema = {
     type_ : string;
@@ -349,14 +388,14 @@ module PrimitiveSchema : sig
     enum : string list;
     enum_names : string list option;
   }
-  [@@deriving yojson]
+  [@@deriving yojson { strict = false }]
 
   type t =
     | String of string_schema
     | Number of number_schema
     | Boolean of boolean_schema
     | Enum of enum_schema
-  [@@deriving yojson]
+  [@@deriving yojson { strict = false }]
 end
 
 (** Elicitation schema for structured input. *)

--- a/lib/ocaml-mcp-server/tool_adapter.ml
+++ b/lib/ocaml-mcp-server/tool_adapter.ml
@@ -53,10 +53,15 @@ let register_tool (type args out err)
               Mcp.Request.Tools.Call.content =
                 [
                   Mcp.Types.Content.Text
-                    { type_ = "text"; text = Yojson.Safe.to_string json_output };
+                    {
+                      type_ = "text";
+                      text = Yojson.Safe.to_string json_output;
+                      meta = None;
+                    };
                 ];
               is_error = Some false;
               structured_content = Some json_output;
+              meta = None;
             }
       | Error err ->
           Ok
@@ -64,10 +69,15 @@ let register_tool (type args out err)
               Mcp.Request.Tools.Call.content =
                 [
                   Mcp.Types.Content.Text
-                    { type_ = "text"; text = error_to_string (module T) err };
+                    {
+                      type_ = "text";
+                      text = error_to_string (module T) err;
+                      meta = None;
+                    };
                 ];
               is_error = Some true;
               structured_content = None;
+              meta = None;
             })
 
 (** Register all ocaml-platform-sdk tools *)

--- a/mcp.opam
+++ b/mcp.opam
@@ -17,6 +17,7 @@ depends: [
   "yojson"
   "ppx_deriving_yojson"
   "logs"
+  "re"
   "odoc" {with-doc}
 ]
 build: [

--- a/mcp.opam
+++ b/mcp.opam
@@ -15,6 +15,7 @@ depends: [
   "jsonrpc"
   "jsonschema"
   "yojson"
+  "ppx_inline_test"
   "ppx_deriving_yojson"
   "logs"
   "re"

--- a/test/cancel.t/run.t
+++ b/test/cancel.t/run.t
@@ -1,0 +1,9 @@
+Test cancel notifications.
+
+Testing that the "requestId" parameter is correctly parsed as a string or a int:
+  $ (
+  >   echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+  >   echo '{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":2,"reason":"This operation was aborted"}}'
+  >   echo '{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":"a-string-id","reason":"This operation was aborted"}}'
+  > ) | ocaml-mcp-server --stdio --no-dune
+  {"id":1,"jsonrpc":"2.0","result":{"protocolVersion":"2025-06-18","capabilities":{"logging":{"enabled":true},"tools":{"listChanged":false}},"serverInfo":{"name":"ocaml-mcp-server","version":"0.1.0"}}}

--- a/test/meta.t/run.t
+++ b/test/meta.t/run.t
@@ -1,0 +1,34 @@
+Test _meta field support in OCaml MCP Server
+
+Start the MCP server in the background
+  $ ocaml-mcp-server --pipe test.sock &
+  $ SERVER_PID=$!
+  $ sleep 1
+
+Test 1: Tool call without metadata
+  $ mcp --pipe test.sock call fs_write -a '{"file_path":"/tmp/test.txt","content":"hello"}'
+  {"path":"/tmp/test.txt","formatted":false,"diagnostics":null}
+
+Test 2: Tool call with valid metadata
+  $ mcp --pipe test.sock call fs_write -a '{"file_path":"/tmp/test-meta.txt","content":"hello"}' --meta '{"client/id":"test-123","debug.enabled":true}'
+  {"path":"/tmp/test-meta.txt","formatted":false,"diagnostics":null}
+
+Test 3: Tool call with invalid metadata (reserved prefix)
+  $ mcp --pipe test.sock call fs_write -a '{"file_path":"/tmp/test-bad.txt","content":"hello"}' --meta '{"mcp.dev/internal":"value"}' 2>&1 | head -1
+  Fatal error: exception Failure("Request failed: JSON-RPC error")
+
+Test 4: Tool call with single-character prefix (should work)
+  $ mcp --pipe test.sock call fs_write -a '{"file_path":"/tmp/test-single.txt","content":"hello"}' --meta '{"x/feature":"enabled"}'
+  {"path":"/tmp/test-single.txt","formatted":false,"diagnostics":null}
+
+Test 5: List tools with metadata
+  $ mcp --pipe test.sock list tools --meta '{"client/version":"2.0"}' | grep -c "fs_write"
+  1
+
+Test 6: List resources with metadata
+  $ mcp --pipe test.sock list resources --meta '{"client/scope":"test"}' | head -1
+  Resources (0):
+
+Kill the server and clean up
+  $ kill $SERVER_PID 2>/dev/null
+  $ rm -f /tmp/test.txt /tmp/test-meta.txt /tmp/test-single.txt

--- a/test/meta.t/run.t
+++ b/test/meta.t/run.t
@@ -10,23 +10,23 @@ Test 1: Tool call without metadata
   {"path":"/tmp/test.txt","formatted":false,"diagnostics":null}
 
 Test 2: Tool call with valid metadata
-  $ mcp --pipe test.sock call fs_write -a '{"file_path":"/tmp/test-meta.txt","content":"hello"}' --meta '{"client/id":"test-123","debug.enabled":true}'
+  $ mcp --pipe test.sock --meta '{"client/id":"test-123","debug.enabled":true}' call fs_write -a '{"file_path":"/tmp/test-meta.txt","content":"hello"}' 
   {"path":"/tmp/test-meta.txt","formatted":false,"diagnostics":null}
 
 Test 3: Tool call with invalid metadata (reserved prefix)
-  $ mcp --pipe test.sock call fs_write -a '{"file_path":"/tmp/test-bad.txt","content":"hello"}' --meta '{"mcp.dev/internal":"value"}' 2>&1 | head -1
-  Fatal error: exception Failure("Request failed: JSON-RPC error")
+  $ mcp --pipe test.sock --meta '{"mcp.dev/internal":"value"}' call fs_write -a '{"file_path":"/tmp/test-bad.txt","content":"hello"}'  2>&1 | head -1
+  Invalid meta JSON: Using a reserved MCP prefix is not allowed: 'mcp.dev/internal'
 
 Test 4: Tool call with single-character prefix (should work)
-  $ mcp --pipe test.sock call fs_write -a '{"file_path":"/tmp/test-single.txt","content":"hello"}' --meta '{"x/feature":"enabled"}'
+  $ mcp --pipe test.sock --meta '{"x/feature":"enabled"}' call fs_write -a '{"file_path":"/tmp/test-single.txt","content":"hello"}'
   {"path":"/tmp/test-single.txt","formatted":false,"diagnostics":null}
 
 Test 5: List tools with metadata
-  $ mcp --pipe test.sock list tools --meta '{"client/version":"2.0"}' | grep -c "fs_write"
+  $ mcp --pipe test.sock --meta '{"client/version":"2.0"}' list tools | grep -c "fs_write"
   1
 
 Test 6: List resources with metadata
-  $ mcp --pipe test.sock list resources --meta '{"client/scope":"test"}' | head -1
+  $ mcp --pipe test.sock --meta '{"client/scope":"test"}' list resources | head -1
   Resources (0):
 
 Kill the server and clean up


### PR DESCRIPTION
- Fixed JSON serialization for request_id and progress_token fields to comply with MCP protocol specification
- These fields now serialize as plain JSON values (2 or "abc") instead of OCaml variant format (["Int", 2] or ["String", "abc"])
- Added test for request_id serialization

I made progress_token use the same serialization logic since I assumed it to follow the same pattern as request_id but I did not verified against spec.

I noticed while doing some experiment with the new lib from a recent claude-clode client.

:information_source: currently the PR is stacked behind the `_meta` changes otherwise it's hard to test without the mcp server crashing when used from claude. Marking as draft pending merge of parent.